### PR TITLE
[AIENG-183] changes for PTS v2

### DIFF
--- a/launchable/commands/record/build.py
+++ b/launchable/commands/record/build.py
@@ -221,7 +221,7 @@ def build(
     def collect_commits():
         if not no_commit_collection:
             for w in ws:
-                ctx.invoke(commit, source=w.dir, max_days=max_days, scrub_pii=scrub_pii)
+                ctx.invoke(commit, name=w.name, source=w.dir, max_days=max_days)
         else:
             click.echo(click.style(
                 "Warning: Commit collection is turned off. The commit data must be collected separately.",


### PR DESCRIPTION
- Don't bother sending non-text files. The server can't deal with anyway
- To differentiate multiple repositories within the same workspace, I decided to capture the repository name when collecting files.
- (Boy scout rule) The deprecated scrub_pii switch was removed. It's always on.