### PR TITLE
[chore] report an error in subset call

### DIFF
--- a/launchable/commands/subset.py
+++ b/launchable/commands/subset.py
@@ -560,6 +560,7 @@ def subset(
                 # The status code 422 is returned when validation error of the test mapping file occurs.
                 if res.status_code == 422:
                     print_error_and_die("Error: {}".format(res.reason), Tracking.ErrorEvent.USER_ERROR)
+                res.raise_for_status()
 
                 return SubsetResult.from_response(res.json())
             except Exception as e:


### PR DESCRIPTION
It looks like c41d9a6270d448168e722155b25ac04b7bdad5fa removed the `raise_for_status` check, without which error message from the server won't be reported, even as a warning.

This breaks the subset call in case of the server failure, since `res.json()` looks as if it's returning an empty subset

Assigning the review to @Konboi to make sure  the change in c41d9a6270d448168e722155b25ac04b7bdad5fa is unintentional.