### PR TITLE
[chore] to display with pager

### DIFF
--- a/launchable/commands/compare/subsets.py
+++ b/launchable/commands/compare/subsets.py
@@ -47,4 +47,4 @@ def subsets(file_before, file_after):
         (before, after, f"{diff:+}" if isinstance(diff, int) else diff, test)
         for before, after, diff, test in rows
     ]
-    click.echo(tabulate(tabular_data, headers=headers, tablefmt="github"))
+    click.echo_via_pager(tabulate(tabular_data, headers=headers, tablefmt="github"))

--- a/launchable/commands/inspect/subset.py
+++ b/launchable/commands/inspect/subset.py
@@ -65,7 +65,7 @@ class SubsetResultTableDisplay(SubsetResultAbstractDisplay):
                     result._estimated_duration_sec,
                 ]
             )
-        click.echo(tabulate(rows, header, tablefmt="github", floatfmt=".2f"))
+        click.echo_via_pager(tabulate(rows, header, tablefmt="github", floatfmt=".2f"))
 
 
 class SubsetResultJSONDisplay(SubsetResultAbstractDisplay):


### PR DESCRIPTION
When the result of subset is large, the customer has to scroll up to see the beginning.  
As a result, the less useful output is shown first.  

To avoid this, we should display the results of inspect and compare in a pager view.  