### PR TITLE
Fix CI on the v1 branch

### DIFF
--- a/tests/commands/test_api_error.py
+++ b/tests/commands/test_api_error.py
@@ -3,6 +3,7 @@ import os
 import platform
 import tempfile
 import threading
+import time
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 from unittest import mock
@@ -464,4 +465,11 @@ class APIErrorTest(CliTestCase):
     def assert_tracking_count(self, tracking, count: int):
         # Prior to 3.6, `Response` object can't be obtained.
         if compare_version([int(x) for x in platform.python_version().split('.')], [3, 7]) >= 0:
-            assert tracking.call_count == count
+            # Sometimes, `tracking.call_count` is not updated immediately. So, wait a moment until it is updated.
+            attempt = 0
+            while tracking.call_count < count:
+                time.sleep(0.1)
+                attempt += 1
+                if attempt > 10:
+                    break
+            self.assertEqual(tracking.call_count, count)

--- a/tests/utils/test_http_client.py
+++ b/tests/utils/test_http_client.py
@@ -51,8 +51,8 @@ class HttpClientTest(TestCase):
 
         # use new session to disable retry
         cli = _HttpClient(session=Session())
-        # /error is an actual endpoint that exists on our service to test the behavior
-        res = cli.request("GET", "intake/error")
+        # /raise_error is an actual endpoint that exists on our service to test the behavior
+        res = cli.request("GET", "intake/raise_error")
         self.assertEqual(res.status_code, 500)
         self.assertEqual(res.reason, "Welp")
 


### PR DESCRIPTION
```
======================================================================
FAIL [1.113s]: test_all_workflow_when_server_down (tests.commands.test_api_error.APIErrorTest.test_all_workflow_when_server_down)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/.local/share/virtualenvs/smart-tests-cli-djAcMpSV/lib/python3.11/site-packages/responses/__init__.py", line 232, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/unittest/mock.py", line 1831, in _inner
    return f(*args, **kw)
           ^^^^^^^^^^^^^^
  File "/home/runner/work/smart-tests-cli/smart-tests-cli/tests/commands/test_api_error.py", line 440, in test_all_workflow_when_server_down
    self.assert_tracking_count(tracking=tracking, count=6)
  File "/home/runner/work/smart-tests-cli/smart-tests-cli/tests/commands/test_api_error.py", line 467, in assert_tracking_count
    assert tracking.call_count == count
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError

======================================================================
FAIL [0.341s]: test_reason (tests.utils.test_http_client.HttpClientTest.test_reason)
make sure we correctly propagate error message from the server
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/smart-tests-cli/smart-tests-cli/tests/utils/test_http_client.py", line 57, in test_reason
    self.assertEqual(res.reason, "Welp")
AssertionError: '' != 'Welp'
+ Welp

```