### PR TITLE
feat(AIENG-625): Add support for SMART_TESTS_MATRIX environment varia…

### DIFF
--- a/smart_tests/commands/subset.py
+++ b/smart_tests/commands/subset.py
@@ -27,7 +27,7 @@ from ..app import Application
 from ..args4p.command import Group
 from ..args4p.converters import fileText, floatType, intType
 from ..testpath import FilePathNormalizer, TestPath
-from ..utils.env_keys import REPORT_ERROR_KEY
+from ..utils.env_keys import MATRIX_KEY, REPORT_ERROR_KEY
 from ..utils.fail_fast_mode import (FailFastModeValidateParams, fail_fast_mode_validate,
                                     set_fail_fast_mode, warn_and_exit_if_fail_fast_mode)
 from ..utils.input_snapshot import InputSnapshotId
@@ -453,6 +453,16 @@ class Subset(TestPathWriter):
         self.output_handler = self._default_output_handler
         self.exclusion_output_handler = self._default_exclusion_output_handler
 
+        raw_matrix = os.environ.get(MATRIX_KEY)
+        if raw_matrix:
+            try:
+                matrix = json.loads(raw_matrix)
+                self.flavors = {str(k): str(v) for k, v in matrix.items()} if isinstance(matrix, dict) else {}
+            except (ValueError, AttributeError):
+                self.flavors = {}
+        else:
+            self.flavors = {}
+
     def _default_output_handler(self, output: list[TestPath], rests: list[TestPath]):
         if self.rest:
             self.write_file(self.rest, rests)
@@ -616,6 +626,9 @@ class Subset(TestPathWriter):
         split_subset = self._build_split_subset_payload()
         if split_subset:
             payload['splitSubset'] = split_subset
+
+        if self.flavors:
+            payload['flavors'] = self.flavors
 
         return payload
 

--- a/smart_tests/utils/env_keys.py
+++ b/smart_tests/utils/env_keys.py
@@ -18,6 +18,9 @@ CALLER_KEY = "SMART_TESTS_CALLER"
 # Legacy token key for backward compatibility
 LEGACY_TOKEN_KEY = "LAUNCHABLE_TOKEN"
 
+# GitHub Actions matrix as JSON, e.g. SMART_TESTS_MATRIX='{"shard":"1","os":"ubuntu"}'
+MATRIX_KEY = "SMART_TESTS_MATRIX"
+
 
 def get_token():
     """Get token with backward compatibility for LAUNCHABLE_TOKEN."""

--- a/smart_tests/utils/env_keys.py
+++ b/smart_tests/utils/env_keys.py
@@ -18,8 +18,8 @@ CALLER_KEY = "SMART_TESTS_CALLER"
 # Legacy token key for backward compatibility
 LEGACY_TOKEN_KEY = "LAUNCHABLE_TOKEN"
 
-# GitHub Actions matrix as JSON, e.g. SMART_TESTS_MATRIX='{"shard":"1","os":"ubuntu"}'
-MATRIX_KEY = "SMART_TESTS_MATRIX"
+# GitHub Actions matrix as JSON, e.g. SMART_TEST_GITHUB_ACTIONS_MATRIX='{"shard":"1","os":"ubuntu"}'
+MATRIX_KEY = "SMART_TEST_GITHUB_ACTIONS_MATRIX"
 
 
 def get_token():

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -1249,3 +1249,36 @@ class SubsetTest(CliTestCase):
         self.assert_exit_code(result, 1)
         self.assertIn("owner/repo", result.stderr)
         self.assertIn("no-slash", result.stderr)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {
+        "SMART_TESTS_TOKEN": CliTestCase.smart_tests_token,
+        "SMART_TESTS_MATRIX": '{"shard": "1", "os": "ubuntu"}',
+    })
+    def test_subset_sends_flavors_from_matrix_env_var(self):
+        pipe = "test_1.py"
+        result = self.cli(
+            "subset", "file",
+            "--target", "50%",
+            "--session", self.session,
+            mix_stderr=False,
+            input=pipe,
+        )
+        self.assert_success(result)
+        payload = self.decode_request_body(self.find_request('/subset').request.body)
+        self.assertEqual(payload.get('flavors'), {"shard": "1", "os": "ubuntu"})
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"SMART_TESTS_TOKEN": CliTestCase.smart_tests_token})
+    def test_subset_sends_no_flavors_when_matrix_env_var_absent(self):
+        pipe = "test_1.py"
+        result = self.cli(
+            "subset", "file",
+            "--target", "50%",
+            "--session", self.session,
+            mix_stderr=False,
+            input=pipe,
+        )
+        self.assert_success(result)
+        payload = self.decode_request_body(self.find_request('/subset').request.body)
+        self.assertNotIn('flavors', payload)

--- a/tests/commands/test_subset.py
+++ b/tests/commands/test_subset.py
@@ -1253,7 +1253,7 @@ class SubsetTest(CliTestCase):
     @responses.activate
     @mock.patch.dict(os.environ, {
         "SMART_TESTS_TOKEN": CliTestCase.smart_tests_token,
-        "SMART_TESTS_MATRIX": '{"shard": "1", "os": "ubuntu"}',
+        "SMART_TEST_GITHUB_ACTIONS_MATRIX": '{"shard": "1", "os": "ubuntu"}',
     })
     def test_subset_sends_flavors_from_matrix_env_var(self):
         pipe = "test_1.py"


### PR DESCRIPTION
This pull request adds support for passing environment-specific "flavors" to the subset command via a new environment variable, and includes tests to verify the new behavior. The main changes introduce reading a JSON matrix from the environment, incorporating it into the payload, and ensuring robust handling and testing of this feature.

**Support for matrix flavors via environment variable:**

* Added new environment variable `SMART_TESTS_MATRIX` (imported as `MATRIX_KEY`), which is expected to contain a JSON object describing test matrix flavors (e.g. shard, OS). (`smart_tests/utils/env_keys.py`, `smart_tests/commands/subset.py`) [[1]](diffhunk://#diff-254ac2ff0ad7467f5a164e24ede3e2c196c589d872320e913b1082f946b67434R21-R23) [[2]](diffhunk://#diff-63ab4a20feb4921852d793d93ec6d53d7d1de55a0d404b801bc9815d951d8e2bL29-R29)
* Updated the `subset` command to parse the `SMART_TESTS_MATRIX` environment variable, extract its contents into a `flavors` dictionary, and include it in the payload sent to the server if present. (`smart_tests/commands/subset.py`) [[1]](diffhunk://#diff-63ab4a20feb4921852d793d93ec6d53d7d1de55a0d404b801bc9815d951d8e2bR354-R363) [[2]](diffhunk://#diff-63ab4a20feb4921852d793d93ec6d53d7d1de55a0d404b801bc9815d951d8e2bR516-R518)

**Testing and validation:**

* Added tests to verify that when the `SMART_TESTS_MATRIX` environment variable is set, its contents are correctly sent as `flavors` in the payload, and that no `flavors` field is sent when the variable is absent. (`tests/commands/test_subset.py`)…ble to send flavors in subset payload