### PR TITLE
fix: use self.tracking_client in subset error path

### DIFF
--- a/smart_tests/commands/subset.py
+++ b/smart_tests/commands/subset.py
@@ -881,7 +881,7 @@ class Subset(TestPathWriter):
 
         if self._requires_test_input():
             if self.input_given:
-                print_error_and_die("ERROR: Given arguments did not match any tests. They appear to be incorrect/non-existent.", tracking_client, Tracking.ErrorEvent.USER_ERROR)  # noqa E501
+                print_error_and_die("ERROR: Given arguments did not match any tests. They appear to be incorrect/non-existent.", self.tracking_client, Tracking.ErrorEvent.USER_ERROR)  # noqa E501
             else:
                 print_error_and_die(
                     "ERROR: Expecting tests to be given, but none provided. See https://help.launchableinc.com/features/predictive-test-selection/requesting-and-running-a-subset-of-tests/ and provide ones, or use the `--get-tests-from-previous-sessions` option",  # noqa E501


### PR DESCRIPTION
## Summary
- Fixed a typo in `subset.py:884` where `tracking_client` was used instead of `self.tracking_client`
- This caused a `NameError` that masked the actual user-facing error message ("Given arguments did not match any tests")
- Discovered via https://github.com/Konboi/smart-tests-hands-on-lab-demo-internal/actions/runs/33050046719/job/98443048383

## Test plan
- [ ] Run `smart-tests subset maven` with an invalid source root (e.g. `src/main/java`) and confirm the correct error message is displayed instead of a `NameError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)