### PR TITLE
Revive `inspect tests` command for coding agent compatibility

### DIFF
--- a/smart_tests/commands/inspect/__init__.py
+++ b/smart_tests/commands/inspect/__init__.py
@@ -2,6 +2,7 @@ from ... import args4p
 from ...app import Application
 from .model import model
 from .subset import subset
+from .tests import tests
 
 
 @args4p.group(help="Inspect test and subset data")
@@ -11,3 +12,4 @@ def inspect(app: Application):
 
 inspect.add_command(model)
 inspect.add_command(subset)
+inspect.add_command(tests)

--- a/smart_tests/commands/inspect/tests.py
+++ b/smart_tests/commands/inspect/tests.py
@@ -1,0 +1,176 @@
+import json
+import sys
+from abc import ABCMeta, abstractmethod
+from http import HTTPStatus
+from typing import Annotated, List
+
+import click
+from tabulate import tabulate
+
+import smart_tests.args4p.typer as typer
+
+from ... import args4p
+from ...app import Application
+from ...utils.authentication import ensure_org_workspace
+from ...utils.smart_tests_client import SmartTestsClient
+
+
+class TestResult(object):
+    def __init__(self, result: dict):
+        self._status = result.get("status", "")
+        self._duration_sec = result.get("duration", 0.0)
+        self._created_at = result.get("createdAt", None)
+        self._test_path = "#".join([path["type"] + "=" + path["name"]
+                                   for path in result["testPath"] if path.keys() >= {"type", "name"}])
+
+
+class TestResults(object):
+    def __init__(self, test_session_id: int, results: List[TestResult]):
+        self._test_session_id = test_session_id
+        self._results = results
+
+    def add(self, result: TestResult):
+        self._results.append(result)
+
+    def list(self) -> List[TestResult]:
+        return self._results
+
+    def total_duration_sec(self) -> float:
+        return sum([result._duration_sec for result in self._results])
+
+    def total_duration_min(self) -> float:
+        return (sum([result._duration_sec for result in self._results]) / 60)
+
+    def total_count(self) -> int:
+        return len(self._results)
+
+    def filter_by_status(self, status: str) -> 'TestResults':
+        return TestResults(self._test_session_id, [result for result in self._results if result._status == status])
+
+
+class TestResultAbstractDisplay(metaclass=ABCMeta):
+    def __init__(self, results: TestResults):
+        self._results = results
+
+    @abstractmethod
+    def display(self):
+        raise NotImplementedError("display method is not implemented")
+
+
+class TestResultJSONDisplay(TestResultAbstractDisplay):
+    def __init__(self, results: TestResults):
+        super().__init__(results)
+
+    def display(self):
+        result_json = {}
+        result_json["summary"] = {
+            "total": {
+                "report_count": self._results.total_count(),
+                "duration_min": round(self._results.total_duration_min(), 2),
+            },
+            "success": {
+                "report_count": self._results.filter_by_status("SUCCESS").total_count(),
+                "duration_min": round(self._results.filter_by_status("SUCCESS").total_duration_min(), 2)
+            },
+            "failure": {
+                "report_count": self._results.filter_by_status("FAILURE").total_count(),
+                "duration_min": round(self._results.filter_by_status("FAILURE").total_duration_min(), 2)
+            },
+            "skip": {
+                "report_count": self._results.filter_by_status("SKIPPED").total_count(),
+                "duration_min": round(self._results.filter_by_status("SKIPPED").total_duration_min(), 2)
+            }
+        }
+        result_json["results"] = []
+        for result in self._results.list():
+            result_json["results"].append({
+                "test_path": result._test_path,
+                "duration_sec": result._duration_sec,
+                "status": result._status,
+                "created_at": result._created_at
+            })
+
+        org, workspace = ensure_org_workspace()
+        result_json["test_session_app_url"] = (
+            f"https://app.launchableinc.com/organizations/{org}/workspaces/{workspace}"
+            f"/test-sessions/{self._results._test_session_id}")
+
+        click.echo(json.dumps(result_json, indent=2))
+
+
+class TestResultTableDisplay(TestResultAbstractDisplay):
+    def __init__(self, results: TestResults):
+        super().__init__(results)
+
+    def display(self):
+        header = ["Test Path",
+                  "Duration (sec)", "Status", "Uploaded At"]
+        rows = []
+        for result in self._results.list():
+            rows.append(
+                [
+                    result._test_path,
+                    result._duration_sec,
+                    result._status,
+                    result._created_at,
+                ]
+            )
+        click.echo(tabulate(rows, header, tablefmt="github", floatfmt=".2f"))
+
+        summary_header = ["Summary", "Report Count", "Total Duration (min)"]
+        summary_rows = [
+            ["Total", self._results.total_count(),
+             self._results.total_duration_min()],
+            ["Success", self._results.filter_by_status("SUCCESS").total_count(),
+             self._results.filter_by_status("SUCCESS").total_duration_min()],
+            ["Failure", self._results.filter_by_status("FAILURE").total_count(),
+             self._results.filter_by_status("FAILURE").total_duration_min()],
+            ["Skip", self._results.filter_by_status("SKIPPED").total_count(),
+             self._results.filter_by_status("SKIPPED").total_duration_min()]]
+
+        click.echo(tabulate(summary_rows, summary_header, tablefmt="grid", floatfmt=["", ".0f", ".2f"]))
+
+
+@args4p.command(help="Inspect test session results")
+def tests(
+        app: Application,
+        test_session_id: Annotated[int, typer.Option(
+            '--test-session-id',
+            help="Test session ID",
+            required=True,
+        )],
+        is_json_format: Annotated[bool, typer.Option(
+            '--json',
+            help="Display JSON format"
+        )] = False):
+    client = SmartTestsClient(app=app)
+
+    try:
+        res = client.request(
+            "get", f"/test_sessions/{test_session_id}/events")
+
+        if res.status_code == HTTPStatus.NOT_FOUND:
+            click.echo(click.style(
+                f"Test session {test_session_id} not found. Check test session ID and try again.", 'yellow'),
+                err=True,
+            )
+            sys.exit(1)
+
+        res.raise_for_status()
+        results = res.json()
+    except Exception as e:
+        client.print_exception_and_recover(e, "Warning: failed to inspect tests")
+        return
+
+    test_results = TestResults(test_session_id=test_session_id, results=[])
+    for result in results:
+        if result.keys() >= {"testPath"}:
+            test_results.add(TestResult(result))
+
+    displayer: TestResultAbstractDisplay
+    if is_json_format:
+        displayer = TestResultJSONDisplay(test_results)
+    else:
+        displayer = TestResultTableDisplay(test_results)
+
+    displayer.display()

--- a/smart_tests/commands/inspect/tests.py
+++ b/smart_tests/commands/inspect/tests.py
@@ -77,8 +77,8 @@ class TestResultJSONDisplay(TestResultAbstractDisplay):
                 "duration_min": round(self._results.filter_by_status("FAILURE").total_duration_min(), 2)
             },
             "skip": {
-                "report_count": self._results.filter_by_status("SKIPPED").total_count(),
-                "duration_min": round(self._results.filter_by_status("SKIPPED").total_duration_min(), 2)
+                "report_count": self._results.filter_by_status("SKIP").total_count(),
+                "duration_min": round(self._results.filter_by_status("SKIP").total_duration_min(), 2)
             }
         }
         result_json["results"] = []

--- a/tests/commands/inspect/test_tests.py
+++ b/tests/commands/inspect/test_tests.py
@@ -1,0 +1,156 @@
+import os
+from unittest import mock
+
+import responses  # type: ignore
+
+from smart_tests.utils.http_client import get_base_url
+from tests.cli_test_case import CliTestCase
+
+
+class TestsTest(CliTestCase):
+    response_json = [
+        {"testPath": [
+            {
+                "type": "file",
+                "name": "test_file1.py",
+            },
+        ],
+            "duration": 1.2,
+            "stderr": "",
+            "stdout": "",
+            "createdAt": "2021-01-02T03:04:05.000+00:00",
+            "status": "SUCCESS",
+        },
+        {"testPath": [
+            {
+                "type": "file",
+                "name": "test_file3.py",
+            },
+        ],
+            "duration": 0.6,
+            "stderr": "",
+            "stdout": "",
+            "createdAt": "2021-01-02T03:04:05.000+00:00",
+            "status": "SUCCESS",
+        },
+
+
+        {"testPath": [
+            {
+                "type": "file",
+                "name": "test_file4.py",
+            },
+        ],
+            "duration": 1.8,
+            "stderr": "",
+            "stdout": "",
+            "createdAt": "2021-01-02T03:04:05.000+00:00",
+            "status": "FAILURE",
+        },
+        {"testPath": [
+            {
+                "type": "file",
+                "name": "test_file2.py",
+            },
+        ],
+            "duration": 0.1,
+            "stderr": "",
+            "stdout": "",
+            "createdAt": "2021-01-02T03:04:05.000+00:00",
+            "status": "FAILURE",
+        },
+    ]
+
+    expect = """| Test Path          |   Duration (sec) | Status   | Uploaded At                   |
+|--------------------|------------------|----------|-------------------------------|
+| file=test_file1.py |             1.20 | SUCCESS  | 2021-01-02T03:04:05.000+00:00 |
+| file=test_file3.py |             0.60 | SUCCESS  | 2021-01-02T03:04:05.000+00:00 |
+| file=test_file4.py |             1.80 | FAILURE  | 2021-01-02T03:04:05.000+00:00 |
+| file=test_file2.py |             0.10 | FAILURE  | 2021-01-02T03:04:05.000+00:00 |
++-----------+----------------+------------------------+
+| Summary   |   Report Count |   Total Duration (min) |
++===========+================+========================+
+| Total     |              4 |                   0.06 |
++-----------+----------------+------------------------+
+| Success   |              2 |                   0.03 |
++-----------+----------------+------------------------+
+| Failure   |              2 |                   0.03 |
++-----------+----------------+------------------------+
+| Skip      |              0 |                   0.00 |
++-----------+----------------+------------------------+
+"""
+
+    expect_json = """{
+  "summary": {
+    "total": {
+      "report_count": 4,
+      "duration_min": 0.06
+    },
+    "success": {
+      "report_count": 2,
+      "duration_min": 0.03
+    },
+    "failure": {
+      "report_count": 2,
+      "duration_min": 0.03
+    },
+    "skip": {
+      "report_count": 0,
+      "duration_min": 0.0
+    }
+  },
+  "results": [
+    {
+      "test_path": "file=test_file1.py",
+      "duration_sec": 1.2,
+      "status": "SUCCESS",
+      "created_at": "2021-01-02T03:04:05.000+00:00"
+    },
+    {
+      "test_path": "file=test_file3.py",
+      "duration_sec": 0.6,
+      "status": "SUCCESS",
+      "created_at": "2021-01-02T03:04:05.000+00:00"
+    },
+    {
+      "test_path": "file=test_file4.py",
+      "duration_sec": 1.8,
+      "status": "FAILURE",
+      "created_at": "2021-01-02T03:04:05.000+00:00"
+    },
+    {
+      "test_path": "file=test_file2.py",
+      "duration_sec": 0.1,
+      "status": "FAILURE",
+      "created_at": "2021-01-02T03:04:05.000+00:00"
+    }
+  ],
+  "test_session_app_url": "https://app.launchableinc.com/organizations/launchableinc/workspaces/mothership/test-sessions/16"
+}
+"""
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.smart_tests_token})
+    def test_tests(self):
+        responses.replace(responses.GET, "{}/intake/organizations/{}/workspaces/{}/test_sessions/{}/events".format(
+            get_base_url(),
+            self.organization,
+            self.workspace,
+            self.session_id), json=self.response_json, status=200)
+
+        result = self.cli('inspect', 'tests', '--test-session-id', self.session_id, mix_stderr=False)
+        self.assert_success(result)
+        self.assertEqual(result.stdout, self.expect)
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"LAUNCHABLE_TOKEN": CliTestCase.smart_tests_token})
+    def test_tests_json_format(self):
+        responses.replace(responses.GET, "{}/intake/organizations/{}/workspaces/{}/test_sessions/{}/events".format(
+            get_base_url(),
+            self.organization,
+            self.workspace,
+            self.session_id), json=self.response_json, status=200)
+
+        result = self.cli('inspect', 'tests', "--json", '--test-session-id', self.session_id)
+        self.assert_success(result)
+        self.assertEqual(result.stdout, self.expect_json)


### PR DESCRIPTION
## Why

The `inspect tests` subcommand existed in v1 (`launchable inspect tests`) and was initially ported to v2 but later removed because the functionality was available in the webapp. However, this command is particularly well-suited for AI agents that need programmatic access to test session results (table or JSON output), making it worth reviving.

## What

- Restored `smart_tests/commands/inspect/tests.py` from the last v2-compatible version (before commit `8252cb57`)
- Registered the `tests` subcommand in `smart_tests/commands/inspect/__init__.py`
- Restored tests in `tests/commands/inspect/test_tests.py`

Minor style alignments from the original:
- Import style aligned with `subset.py` (`import smart_tests.args4p.typer as typer`)
- Fixed `--test-session-id` help text (was incorrectly "display JSON format")
- Consistent use of f-strings
- Added command help text (`"Inspect test session results"`)

Usage: `smart-tests inspect tests --test-session-id <ID> [--json]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)